### PR TITLE
fix issue that duplicate monitoring cloudwatch stats

### DIFF
--- a/scripts/cloudwatch_zabbix.py
+++ b/scripts/cloudwatch_zabbix.py
@@ -119,7 +119,9 @@ class AwsZabbix:
 
     def __get_send_items(self, stats, metric):
         send_items = []
-        for datapoint in stats["Datapoints"]:
+        datapoints = stats["Datapoints"]
+        datapoints = sorted(datapoints, key=lambda datapoints: datapoints["Timestamp"], reverse=True)
+        for datapoint in datapoints:
             servicename = ''
             send_json_string = '{"host":"", "key":"", "value":"", "clock":""}'
             send_item = json.loads(send_json_string)
@@ -135,6 +137,7 @@ class AwsZabbix:
             send_item["value"] = str(datapoint["Average"])
             send_item["clock"] = calendar.timegm(datapoint["Timestamp"].utctimetuple())
             send_items.append(send_item)
+            break
         return send_items
 
 


### PR DESCRIPTION
fix the issue that AWS monitoring template monitor the same stat data twice.
